### PR TITLE
feat: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## How to contribute to MarsBased Handbook
+
+We welcome any suggestion, and we encourage discussions.
+
+This is an opinionated resource. In order to change these guides a vast majority of the MarsBased developers should agree. You can open a PR directly with your suggestions or you can create an issue to discuss and collect opinions before opening it.
+
+Ask any question about the guides opening an issue.
+
+## Submitting changes
+
+We'll reject any proposal that is not properly documented and argued. Take your time before submitting a PR.
+
+1. Fork the repository and commit your changes following [Our Git & Commit guidelines](/guides/development/git-guidelines.md)
+2. Open a new GitHub pull request with the patch.
+3. Ensure the PR description clearly describes the change and the reasons. Include the relevant issue number if applicable and additional resources and links if possible.
+
+

--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ For now, we have the following resources available:
 1. <a href="https://marsbased.us7.list-manage.com/subscribe/post?u=1ab50c539712be36367b96b98&amp;id=89db0a6312" title="MarsBased newsletter" target="_blank">MarsBased newsletter</a>
 1. <a href="https://www.youtube.com/channel/UCN95eGlyCaRBa9Iy12mVApg" title="MarsBased YouTube channel" target="_blank">MarsBased YouTube channel</a>
 1. <a href="https://github.com/MarsBased/productivity" title="Productivity: A repo containing productivity hacks (for now, only TextExpander snippets)" target="_blank">Productivity: A repo containing productivity hacks (for now, only TextExpander snippets)</a>
+
+# Contributing
+We encourage you to contribute! Please check out the [Contributing guides](./CONTRIBUTING.md) for guidelines about how to proceed.


### PR DESCRIPTION
## Reason for change

Closes #45 

We're adding a contributing document, mainly to force contributors to explain themselves better, documenting and referencing their points of view.

## List of Changes

- Add a contributing doc link to the README.
- Add a contributing guide.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [X] I have updated necessary documentation and links in the README.md or the doc folder
- [X] I have rebased from master, written good commit messages and squashed unnecessary commits