### PR TITLE
docs(docker): Add public bucket command for minio

### DIFF
--- a/guides/development/docker-guide/services-and-application-rails/.dockerdev/scripts/create-bucket.sh
+++ b/guides/development/docker-guide/services-and-application-rails/.dockerdev/scripts/create-bucket.sh
@@ -2,3 +2,6 @@
 
 /usr/bin/mc config host add <application-name> http://minio:9000 minio 2NVQWHvTT73XMgqapGchy6yAtwHezMZn;
 /usr/bin/mc mb <application-name>/<application-name>-development;
+
+# If you need your bucket to be public, uncomment this line
+# /usr/bin/mc policy set public <application-name>/<application-name>-development;

--- a/guides/development/docker-guide/services-only/.dockerdev/scripts/create-bucket.sh
+++ b/guides/development/docker-guide/services-only/.dockerdev/scripts/create-bucket.sh
@@ -2,3 +2,6 @@
 
 /usr/bin/mc config host add <application-name> http://minio:9000 minio 2NVQWHvTT73XMgqapGchy6yAtwHezMZn;
 /usr/bin/mc mb <application-name>/<application-name>-development;
+
+# If you need your bucket to be public, uncomment this line
+# /usr/bin/mc policy set public <application-name>/<application-name>-development;


### PR DESCRIPTION
## Reason for change

This is a PullRequest intended to improve the docker development setup of the Minio service.

By default all buckets in minio are private. While this should be the default behaviour there are times when it's desirable them to be public. This PR adds a commented line to the minio scripts to enable this.

## Checklist

- [x] I have updated necessary documentation and links in the README.md or the doc folder
- [x] I have rebased from master, written good commit messages and squashed unnecessary commits