### PR TITLE
fix: Fix rails Docker setup & postgresql

### DIFF
--- a/guides/development/docker-guide/services-and-application-rails/.dockerdev/Dockerfile
+++ b/guides/development/docker-guide/services-and-application-rails/.dockerdev/Dockerfile
@@ -5,6 +5,8 @@ ARG BUNDLER_VERSION
 # Install system dependencies
 RUN apk --update add less bash git curl wget build-base && \
     apk add postgresql-client && \
+    apk add postgresql-dev && \
+    apk add tzdata && \
     apk add nodejs yarn && \
     apk add vim imagemagick && \
     rm -rf /tmp/* /var/tmp/* && \

--- a/guides/development/docker-guide/services-and-application-rails/.dockerdev/docker-compose.yml
+++ b/guides/development/docker-guide/services-and-application-rails/.dockerdev/docker-compose.yml
@@ -99,6 +99,10 @@ services:
       - ./volumes/postgres:/var/lib/postgresql/data
       - ./log:/root/log:cached
     environment:
+      ALLOW_IP_RANGE: 0.0.0.0/0
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: <application-name>_development
       PSQL_HISTFILE: /root/log/.psql_history
     ports:
       - 5432

--- a/guides/development/docker-guide/services-only/.dockerdev/docker-compose.yml
+++ b/guides/development/docker-guide/services-only/.dockerdev/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       - ./volumes/postgres:/var/lib/postgresql/data
       - ./log:/root/log:cached
     environment:
+      ALLOW_IP_RANGE: 0.0.0.0/0
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: <database-name>
       PSQL_HISTFILE: /root/log/.psql_history
     ports:
       - 5432


### PR DESCRIPTION
## Reason for change

After running the docker setup, Rails complained during bundle install. Some pg binaries were missing in the alpine image. Also, during Rails init process it crashed because the Alpine OS didn't have the tzdata library. Those errors has been solved adding those dependencies in the base image installation.

Finally, in order to successfully start the Postgres DB we need to define the username and password env variables.

## List of Changes

- Change Dockerfile image for Rails application
- Change postgres docker-compose to include default username & password

## Checklist

- [x] I have updated necessary documentation and links in the README.md or the doc folder
- [x] I have rebased from master, written good commit messages and squashed unnecessary commits