### PR TITLE
Replace legacy Mailchimp newsletter link with website section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For now, we have the following resources available:
 1. <a href="https://marsbased.com/blog" title="MarsBased blog" target="_blank">MarsBased blog</a>
 1. <a href="https://podcast.marsbased.com/" title="Life on Mars - The MarsBased Podcast, English Edition" target="_blank">Life on Mars - The MarsBased Podcast, English Edition</a>
 1. <a href="https://podcast.marsbased.com/podcasts-es/" title="Life on Mars - The MarsBased Podcast, Spanish Edition" target="_blank">Life on Mars - The MarsBased Podcast, Spanish Edition</a>
-1. <a href="https://marsbased.us7.list-manage.com/subscribe/post?u=1ab50c539712be36367b96b98&amp;id=89db0a6312" title="MarsBased newsletter" target="_blank">MarsBased newsletter</a>
+1. <a href="https://marsbased.com/newsletter" title="MarsBased newsletter" target="_blank">MarsBased newsletter</a>
 1. <a href="https://www.youtube.com/@MarsBased" title="MarsBased YouTube channel" target="_blank">MarsBased YouTube channel</a>
 
 ## Contributing


### PR DESCRIPTION
The newsletter link in the handbook was using a legacy, hardcoded Mailchimp URL (us7.list-manage.com). This PR updates it to link directly to the official newsletter section on the MarsBased website, providing a much cleaner look and keeping traffic within our domain.

Reason for change
The legacy hardcoded Mailchimp subscription URL was outdated and visually unappealing. Directing users to our own website's newsletter section provides a better user experience, looks more professional, and keeps traffic within our domain.

List of Changes
Replaced the legacy us7.list-manage.com hardcoded link with the clean [marsbased.com/newsletter](https://marsbased.com/newsletter) URL.

Updated the formatting from a raw URL to a clean Markdown anchor text link.

Checklist
[x] I have updated necessary documentation and links in the README.md or the doc folder

[ ] I have rebased from main, written good commit messages and squashed unnecessary commits